### PR TITLE
Simplified profile writing, so that a sequence can be set once for multiple cores

### DIFF
--- a/cpu_load_generator/__main__.py
+++ b/cpu_load_generator/__main__.py
@@ -35,6 +35,9 @@ def input_error_handler(args):
     cpu_count = psutil.cpu_count()
 
     if args.path_to_profile_json == "":
+        if(args.cpu_load == None):
+            raise ValueError('CPU load value must be provided')
+
         if not args.cpu_core < cpu_count:
             args.print_help()
             raise ValueError('Core to load should not be higher than {}!'.format(cpu_count - 1))

--- a/cpu_load_generator/_interface.py
+++ b/cpu_load_generator/_interface.py
@@ -70,9 +70,11 @@ def from_profile(path_to_profile_json):
 
     processes = []
     for single_sequence in profile:
-        process = mp.Process(target=_run_single_sequence,
-                             args=(single_sequence["cpu_num"], single_sequence["repeat"], single_sequence["sequence"]))
-        processes.append(process)
+        targets = single_sequence["target_cpus"]
+        for target in targets:
+            process = mp.Process(target=_run_single_sequence,
+                                args=(target, single_sequence["repeat"], single_sequence["sequence"]))
+            processes.append(process)
 
     for process in processes:
         process.start()

--- a/load_profiles/default_profile.json
+++ b/load_profiles/default_profile.json
@@ -1,37 +1,7 @@
 [
   {
     "repeat": 1,
-    "cpu_num": 0,
-    "sequence": [
-      {
-        "load": 0.5,
-        "duration_s": 10
-      },
-      {
-        "load": 1.0,
-        "duration_s": 10
-      },
-      {
-        "load": 0.1,
-        "duration_s": 10
-      },
-      {
-        "load": 1.0,
-        "duration_s": 10
-      },
-      {
-        "load": 0.1,
-        "duration_s": 10
-      },
-      {
-        "load": 1.0,
-        "duration_s": 10
-      }
-    ]
-  },
-  {
-    "repeat": 2,
-    "cpu_num": 1,
+    "target_cpus": [0, 1, 2, 3],
     "sequence": [
       {
         "load": 0.5,


### PR DESCRIPTION
Hi!
I started to use this package but I found that json profiles could be simplified: now instead of repeating the same sequence for all cores, you can provide a list of cores to apply the sequence to. I also added a check to raise an error in the case the user doesn't provide any input argument.